### PR TITLE
add default-layout-mut-shared feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ default-layout-raw = ["raw-buffer"]
 default-layout-vec = []
 default-layout-mut-any-buffer = []
 default-layout-mut-vec = []
+default-layout-mut-shared = []
 
 [dependencies]
 bytemuck = { version = "1", default-features = false, optional = true }

--- a/bytes/Cargo.toml
+++ b/bytes/Cargo.toml
@@ -9,7 +9,7 @@ std = ["arc-slice/std"]
 portable-atomic = ["arc-slice/portable-atomic"]
 
 [dependencies]
-arc-slice = { version = "0.1.0-alpha.1", path = "..", default-features = false, features = ["abort-on-refcount-overflow", "oom-handling", "default-layout-any-buffer", "default-layout-static", "default-layout-mut-any-buffer"] }
+arc-slice = { version = "0.1.0-alpha.1", path = "..", default-features = false, features = ["abort-on-refcount-overflow", "oom-handling", "default-layout-any-buffer", "default-layout-static", "default-layout-mut-any-buffer", "default-layout-mut-shared"] }
 bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,9 @@
 //! - `default-layout-mut-any-buffer`: set [`ArcLayout`] `ANY_BUFFER` to `true` for [`ArcSliceMut`].
 //! - `default-layout-mut-vec`: override default layout to [`VecLayout`](layout::VecLayout) for
 //!   [`ArcSliceMut`].
+//! - `default-layout-mut-shared`: optimize [`ArcLayout`](layout::ArcLayout) in [`ArcSliceMut`] to
+//!   be mainly used with `UNIQUE=false`; this is the case for example when emulating
+//!   [`BytesMut`](::bytes::BytesMut`).
 //!
 //! [Small String Optimization]: https://cppdepend.com/blog/understanding-small-string-optimization-sso-in-stdstring/
 //! [out-of-memory handling]: alloc::alloc::handle_alloc_error

--- a/src/msrv.rs
+++ b/src/msrv.rs
@@ -213,11 +213,12 @@ impl Zeroable for usize {
 pub struct NonZero<T: Zeroable>(T::NonZero);
 
 impl<T: Zeroable> NonZero<T> {
-    pub(crate) fn new(n: T) -> Option<Self> {
-        T::non_zero(n).map(Self)
+    #[allow(clippy::new_ret_no_self)]
+    pub(crate) fn new<N: From<Self>>(n: T) -> Option<N> {
+        T::non_zero(n).map(Self).map(From::from)
     }
 
-    pub(crate) unsafe fn new_unchecked(n: T) -> Self {
+    pub(crate) unsafe fn new_unchecked<N: From<Self>>(n: T) -> N {
         unsafe { Self::new(n).unwrap_unchecked() }
     }
 
@@ -234,7 +235,7 @@ impl From<NonZero<usize>> for NonZeroUsize {
 
 impl From<NonZeroUsize> for NonZero<usize> {
     fn from(value: NonZeroUsize) -> Self {
-        NonZero::new_checked(value.get())
+        Self(value)
     }
 }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -120,7 +120,7 @@ pub unsafe trait ArcSliceLayout: 'static {
         start: NonNull<S::Item>,
         length: usize,
         data: &mut ManuallyDrop<Self::Data>,
-    ) -> Option<(usize, Option<Data>)>;
+    ) -> Option<(usize, Option<Data<true>>)>;
     fn update_layout<S: Slice + ?Sized, L: ArcSliceLayout, E: AllocErrorImpl>(
         start: NonNull<S::Item>,
         length: usize,

--- a/src/slice/arc.rs
+++ b/src/slice/arc.rs
@@ -151,7 +151,7 @@ unsafe impl<const ANY_BUFFER: bool, const STATIC: bool> ArcSliceLayout
         start: NonNull<S::Item>,
         length: usize,
         data: &mut ManuallyDrop<Self::Data>,
-    ) -> Option<(usize, Option<slice_mut::Data>)> {
+    ) -> Option<(usize, Option<slice_mut::Data<true>>)> {
         match Self::arc::<S>(data) {
             Some(mut arc) => Some((
                 unsafe { arc.capacity(start)? },

--- a/src/slice/raw.rs
+++ b/src/slice/raw.rs
@@ -305,7 +305,7 @@ unsafe impl ArcSliceLayout for RawLayout {
         start: NonNull<S::Item>,
         _length: usize,
         data: &mut ManuallyDrop<Self::Data>,
-    ) -> Option<(usize, Option<slice_mut::Data>)> {
+    ) -> Option<(usize, Option<slice_mut::Data<true>>)> {
         match arc_or_vtable::<S>(**data) {
             ArcOrVTable::Arc(mut arc) => Some((
                 unsafe { arc.capacity(start)? },
@@ -314,7 +314,7 @@ unsafe impl ArcSliceLayout for RawLayout {
             ArcOrVTable::Vtable { ptr, vtable } => {
                 let capacity = unsafe { (vtable.capacity)(ptr, start.cast()) };
                 (capacity != usize::MAX).then(|| {
-                    let data = unsafe { NonNull::new_unchecked(ptr.cast_mut()) }.into();
+                    let data = slice_mut::Data(unsafe { NonNull::new_unchecked(ptr.cast_mut()) });
                     (capacity, Some(data))
                 })
             }

--- a/src/slice/vec.rs
+++ b/src/slice/vec.rs
@@ -295,7 +295,7 @@ unsafe impl<L: BoxedSliceOrVecLayout + 'static> ArcSliceLayout for L {
         start: NonNull<S::Item>,
         length: usize,
         data: &mut ManuallyDrop<Self::Data>,
-    ) -> Option<(usize, Option<slice_mut::Data>)> {
+    ) -> Option<(usize, Option<slice_mut::Data<true>>)> {
         let (ptr, base) = &mut **data;
         match ptr.get_mut::<S>() {
             Data::Static => (length == 0).then_some((0, None)),
@@ -306,7 +306,8 @@ unsafe impl<L: BoxedSliceOrVecLayout + 'static> ArcSliceLayout for L {
             Data::Capacity(capacity) => {
                 let vec = unsafe { Self::rebuild_vec::<S>(start, length, capacity, *base) };
                 let offset = unsafe { vec.offset(start) };
-                let data = Some(unsafe { L2::data_from_vec::<S, AllocError>(vec, offset).ok()? });
+                let data =
+                    Some(unsafe { L2::data_from_vec::<S, AllocError, true>(vec, offset).ok()? });
                 Some((capacity.get() - offset, data))
             }
         }

--- a/src/slice_mut/arc.rs
+++ b/src/slice_mut/arc.rs
@@ -1,5 +1,7 @@
 use core::{any::Any, mem, mem::ManuallyDrop, ptr::NonNull};
 
+#[allow(unused_imports)]
+use crate::msrv::StrictProvenance;
 use crate::{
     arc::Arc,
     buffer::{BufferMut, Slice},
@@ -8,35 +10,107 @@ use crate::{
     msrv::ptr,
     slice::ArcSliceLayout,
     slice_mut::{ArcSliceMutLayout, Data, TryReserveResult},
+    utils::assert_checked,
 };
+#[cfg(feature = "default-layout-mut-shared")]
+use crate::{msrv::NonZero, utils::UnwrapChecked};
+
+#[cfg(feature = "default-layout-mut-shared")]
+const SHARED_FLAG: usize = 0b01;
+
+impl<const UNIQUE: bool> Data<UNIQUE> {
+    #[inline(always)]
+    fn from_arc<S: Slice + ?Sized, const ANY_BUFFER: bool>(arc: Arc<S, ANY_BUFFER>) -> Self {
+        let ptr = arc.into_raw();
+        #[cfg(feature = "default-layout-mut-shared")]
+        let ptr = if !UNIQUE {
+            ptr.map_addr(|addr| NonZero::new(addr.get() | SHARED_FLAG).unwrap_checked())
+        } else {
+            ptr
+        };
+        Data(ptr)
+    }
+
+    #[inline(always)]
+    fn get_arc<S: Slice + ?Sized, const ANY_BUFFER: bool>(
+        &self,
+    ) -> ManuallyDrop<Arc<S, ANY_BUFFER>> {
+        let ptr = self.0;
+        #[cfg(feature = "default-layout-mut-shared")]
+        // MSRV 1.79 NonZero
+        let ptr = if !UNIQUE {
+            ptr.map_addr(|addr| unsafe { NonZero::new_unchecked(addr.get() & !SHARED_FLAG) })
+        } else {
+            ptr
+        };
+        ManuallyDrop::new(unsafe { Arc::from_raw(ptr) })
+    }
+
+    #[cfg(not(feature = "default-layout-mut-shared"))]
+    #[inline(always)]
+    fn is_unique(&self) -> bool {
+        UNIQUE
+    }
+
+    #[cfg(feature = "default-layout-mut-shared")]
+    #[inline(always)]
+    fn is_unique(&self) -> bool {
+        UNIQUE || self.0.addr().get() & SHARED_FLAG == 0
+    }
+
+    #[cfg(not(feature = "default-layout-mut-shared"))]
+    #[inline(always)]
+    fn make_unique(&mut self) {}
+
+    #[cfg(feature = "default-layout-mut-shared")]
+    #[inline(always)]
+    fn make_unique(&mut self) {
+        self.0 = self
+            .0
+            .map_addr(|addr| unsafe { NonZero::new_unchecked(addr.get() & !SHARED_FLAG) });
+    }
+
+    #[cfg(not(feature = "default-layout-mut-shared"))]
+    #[inline(always)]
+    fn make_shared(&mut self) {}
+
+    #[cfg(feature = "default-layout-mut-shared")]
+    #[inline(always)]
+    fn make_shared(&mut self) {
+        self.0 = self
+            .0
+            .map_addr(|addr| unsafe { NonZero::new_unchecked(addr.get() | SHARED_FLAG) });
+    }
+}
 
 unsafe impl<const ANY_BUFFER: bool, const STATIC: bool> ArcSliceMutLayout
     for ArcLayout<ANY_BUFFER, STATIC>
 {
     const ANY_BUFFER: bool = ANY_BUFFER;
-    fn try_data_from_arc<S: Slice + ?Sized, const ANY_BUFFER2: bool>(
+    fn try_data_from_arc<S: Slice + ?Sized, const ANY_BUFFER2: bool, const UNIQUE: bool>(
         arc: ManuallyDrop<Arc<S, ANY_BUFFER2>>,
-    ) -> Option<Data> {
+    ) -> Option<Data<UNIQUE>> {
         ManuallyDrop::into_inner(arc)
             .try_into_arc_slice()
             .map_err(mem::forget)
             .ok()
-            .map(Into::into)
+            .map(Data::from_arc)
     }
-    unsafe fn data_from_vec<S: Slice + ?Sized, E: AllocErrorImpl>(
+    unsafe fn data_from_vec<S: Slice + ?Sized, E: AllocErrorImpl, const UNIQUE: bool>(
         vec: S::Vec,
         _offset: usize,
-    ) -> Result<Data, (E, S::Vec)> {
-        Ok(Arc::<S>::new_vec::<E>(vec)?.into_raw().into())
+    ) -> Result<Data<UNIQUE>, (E, S::Vec)> {
+        Ok(Data::from_arc(Arc::<S>::new_vec::<E>(vec)?))
     }
 
-    fn clone<S: Slice + ?Sized, E: AllocErrorImpl>(
+    fn clone<S: Slice + ?Sized, E: AllocErrorImpl, const UNIQUE: bool>(
         _start: NonNull<S::Item>,
         _length: usize,
         _capacity: usize,
-        data: &mut Data,
+        data: &mut Data<UNIQUE>,
     ) -> Result<(), E> {
-        mem::forget((*data.into_arc::<S, ANY_BUFFER>()).clone());
+        mem::forget((*data.get_arc::<S, ANY_BUFFER>()).clone());
+        data.make_shared();
         Ok(())
     }
 
@@ -44,28 +118,30 @@ unsafe impl<const ANY_BUFFER: bool, const STATIC: bool> ArcSliceMutLayout
         start: NonNull<S::Item>,
         length: usize,
         _capacity: usize,
-        data: Data,
+        data: Data<UNIQUE>,
     ) {
-        let mut arc = ManuallyDrop::into_inner(data.into_arc::<S, ANY_BUFFER>());
+        let mut arc = ManuallyDrop::into_inner(data.get_arc::<S, ANY_BUFFER>());
         arc.set_length::<UNIQUE>(start, length);
-        if UNIQUE {
+        if data.is_unique() {
             unsafe { arc.drop_unique() };
         } else {
             drop(arc);
         }
     }
 
-    fn get_metadata<S: Slice + ?Sized, M: Any>(data: &Data) -> Option<&M> {
-        Some(unsafe { &*ptr::from_ref((*data).into_arc::<S, ANY_BUFFER>().get_metadata()?) })
+    fn get_metadata<S: Slice + ?Sized, M: Any, const UNIQUE: bool>(
+        data: &Data<UNIQUE>,
+    ) -> Option<&M> {
+        Some(unsafe { &*ptr::from_ref((*data).get_arc::<S, ANY_BUFFER>().get_metadata()?) })
     }
 
     unsafe fn take_buffer<S: Slice + ?Sized, B: BufferMut<S>, const UNIQUE: bool>(
         start: NonNull<S::Item>,
         length: usize,
         _capacity: usize,
-        data: Data,
+        data: Data<UNIQUE>,
     ) -> Option<B> {
-        let arc = ManuallyDrop::into_inner(data.into_arc::<S, ANY_BUFFER>());
+        let arc = ManuallyDrop::into_inner(data.get_arc::<S, ANY_BUFFER>());
         unsafe { arc.take_buffer::<B, UNIQUE>(start, length) }
             .map_err(mem::forget)
             .ok()
@@ -74,47 +150,64 @@ unsafe impl<const ANY_BUFFER: bool, const STATIC: bool> ArcSliceMutLayout
     unsafe fn take_array<T: Send + Sync + 'static, const N: usize, const UNIQUE: bool>(
         start: NonNull<T>,
         length: usize,
-        data: Data,
+        data: Data<UNIQUE>,
     ) -> Option<[T; N]> {
-        let arc = ManuallyDrop::into_inner(data.into_arc::<[T], ANY_BUFFER>());
+        let arc = ManuallyDrop::into_inner(data.get_arc::<[T], ANY_BUFFER>());
         unsafe { arc.take_array::<N, false>(start, length) }
             .map_err(mem::forget)
             .ok()
     }
 
-    fn is_unique<S: Slice + ?Sized>(data: Data) -> bool {
-        data.into_arc::<S, ANY_BUFFER>().is_unique()
+    fn is_unique<S: Slice + ?Sized, const UNIQUE: bool>(data: &mut Data<UNIQUE>) -> bool {
+        assert_checked(!UNIQUE);
+        if data.is_unique() {
+            return true;
+        }
+        if data.get_arc::<S, ANY_BUFFER>().is_unique() {
+            data.make_unique();
+            return true;
+        }
+        false
     }
 
     fn try_reserve<S: Slice + ?Sized, const UNIQUE: bool>(
         start: NonNull<S::Item>,
         length: usize,
         _capacity: usize,
-        data: &mut Data,
+        data: &mut Data<UNIQUE>,
         additional: usize,
         allocate: bool,
     ) -> TryReserveResult<S::Item> {
-        let mut arc = (*data).into_arc::<S, ANY_BUFFER>();
+        let mut arc = (*data).get_arc::<S, ANY_BUFFER>();
         let res = unsafe { arc.try_reserve::<UNIQUE>(start, length, additional, allocate) };
-        *data = ManuallyDrop::into_inner(arc).into();
+        if res.0.is_ok() {
+            // Arc::try_reserve may reallocate the arc, but only if it succeeds, and in that case
+            // the data is unique
+            *data = Data(ManuallyDrop::into_inner(arc).into_raw());
+        }
         res
     }
 
-    fn frozen_data<S: Slice + ?Sized, L: ArcSliceLayout, E: AllocErrorImpl>(
+    fn frozen_data<S: Slice + ?Sized, L: ArcSliceLayout, E: AllocErrorImpl, const UNIQUE: bool>(
         _start: NonNull<S::Item>,
         _length: usize,
         _capacity: usize,
-        data: Data,
+        data: Data<UNIQUE>,
     ) -> Option<L::Data> {
-        L::try_data_from_arc(data.into_arc::<S, ANY_BUFFER>())
+        L::try_data_from_arc(data.get_arc::<S, ANY_BUFFER>())
     }
 
-    fn update_layout<S: Slice + ?Sized, L: ArcSliceMutLayout, E: AllocErrorImpl>(
+    fn update_layout<
+        S: Slice + ?Sized,
+        L: ArcSliceMutLayout,
+        E: AllocErrorImpl,
+        const UNIQUE: bool,
+    >(
         _start: NonNull<S::Item>,
         _length: usize,
         _capacity: usize,
-        data: Data,
-    ) -> Option<Data> {
-        L::try_data_from_arc(data.into_arc::<S, ANY_BUFFER>())
+        data: Data<UNIQUE>,
+    ) -> Option<Data<UNIQUE>> {
+        L::try_data_from_arc(data.get_arc::<S, ANY_BUFFER>())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use core::{
     convert::Infallible,
     fmt,
     mem::MaybeUninit,
+    num::NonZeroUsize,
     ops::{Bound, RangeBounds},
     ptr::NonNull,
 };
@@ -12,7 +13,6 @@ use crate::msrv::StrictProvenance;
 use crate::{
     buffer::{Slice, SliceExt, Subsliceable},
     macros::{is, is_not},
-    msrv::{NonZero, Zeroable},
 };
 
 #[inline(always)]
@@ -200,10 +200,10 @@ impl<T: ?Sized> NewChecked<*mut T> for NonNull<T> {
     }
 }
 
-impl<T: Zeroable> NewChecked<T> for NonZero<T> {
+impl NewChecked<usize> for NonZeroUsize {
     #[inline(always)]
-    fn new_checked(arg: T) -> Self {
-        NonZero::new(arg).unwrap_checked()
+    fn new_checked(arg: usize) -> Self {
+        NonZeroUsize::new(arg).unwrap_checked()
     }
 }
 


### PR DESCRIPTION
BytesMut compatibility implementation can only use `ArcSliceMut` with `UNIQUE=false`, so it meant that every drop trigger an atomic decrement. With this new feature, a flag (the same as with `VecLayout`) marks the data to tell if it has been cloned or not.